### PR TITLE
add the vars we need to make image upload and media-browser working

### DIFF
--- a/app/networkapi/settings.py
+++ b/app/networkapi/settings.py
@@ -28,6 +28,7 @@ env = environ.Env(
     CONTENT_TYPE_NO_SNIFF=bool,
     SET_HSTS=bool,
     SSL_REDIRECT=bool,
+    FILEBROWSER_DIRECTORY=(str, ''),
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -228,6 +229,8 @@ if USE_S3:
     AWS_LOCATION = env('AWS_STORAGE_ROOT', default=None)
     MEDIA_URL = 'https://' + env('AWS_S3_CUSTOM_DOMAIN') + '/'
     MEDIA_ROOT = ''
+    FILEBROWSER_DIRECTORY = env('FILEBROWSER_DIRECTORY')
+
 else:
     # Otherwise use the default filesystem storage
     MEDIA_ROOT = root('media/')


### PR DESCRIPTION
This ensures that the filebrowser_safe module hits the correct directory on S3 - if you don't specify your own `FILEBROWSER_DIRECTORY` value, the module will assume you are trying to hit `/uploads/`, which is only a valid assumption when using a local filesystem.

This is an embarrassingly small PR, hiding a good few hours of hunting and testing. 