### PR TITLE
template tag for getting a settings value

### DIFF
--- a/app/networkapi/landingpage/models.py
+++ b/app/networkapi/landingpage/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from mezzanine.pages.models import Page
 from mezzanine.core.fields import RichTextField
 
+
 class Signup(models.Model):
     header = models.CharField(max_length=500)
     description = RichTextField("description")

--- a/app/networkapi/landingpage/models.py
+++ b/app/networkapi/landingpage/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from mezzanine.pages.models import Page
 from mezzanine.core.fields import RichTextField
 
-
 class Signup(models.Model):
     header = models.CharField(max_length=500)
     description = RichTextField("description")

--- a/app/networkapi/settings.py
+++ b/app/networkapi/settings.py
@@ -30,6 +30,7 @@ env = environ.Env(
     SET_HSTS=bool,
     SSL_REDIRECT=bool,
     FILEBROWSER_DIRECTORY=(str, ''),
+    ASSET_DOMAIN=(str, '')
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -139,13 +140,17 @@ TEMPLATES = [
             'libraries': {
                 'adminsortable_tags': 'networkapi.utility.templatetags'
                                       '.adminsortable_tags_custom',
+                'settings_value': 'networkapi.utility.templatetags'
+                                '.settings_value',
                 's3thumbnails': 'networkapi.filebrowser_s3'
                                 '.templatetags.s3thumbnails'
-
             }
         },
     },
 ]
+
+# network asset domain used in templates
+ASSET_DOMAIN = env('ASSET_DOMAIN')
 
 WSGI_APPLICATION = 'networkapi.wsgi.application'
 
@@ -280,3 +285,4 @@ except ImportError:
     pass
 else:
     set_dynamic_settings(globals())
+

--- a/app/networkapi/settings.py
+++ b/app/networkapi/settings.py
@@ -141,7 +141,7 @@ TEMPLATES = [
                 'adminsortable_tags': 'networkapi.utility.templatetags'
                                       '.adminsortable_tags_custom',
                 'settings_value': 'networkapi.utility.templatetags'
-                                '.settings_value',
+                                  '.settings_value',
                 's3thumbnails': 'networkapi.filebrowser_s3'
                                 '.templatetags.s3thumbnails'
             }
@@ -277,6 +277,7 @@ SECURE_SSL_REDIRECT = env('SSL_REDIRECT')
 # See https://docs.djangoproject.com/en/1.10/ref/settings/#secure-ssl-redirect
 if env('SSL_REDIRECT') is True:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 X_FRAME_OPTIONS = env('X_FRAME_OPTIONS')
 
 try:
@@ -285,4 +286,3 @@ except ImportError:
     pass
 else:
     set_dynamic_settings(globals())
-

--- a/app/networkapi/templates/pages/landingpage.html
+++ b/app/networkapi/templates/pages/landingpage.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+  {% load settings_value %}
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,13 +12,13 @@
     <meta property="og:image" content="TODO">
     <meta property="og:title" content="TODO">
     <meta property="og:description" content="TODO">
-    <link rel="stylesheet" href="https://network.mofoprod.net/_css/main.compiled.css">
+    <link rel="stylesheet" href="https://{% settings_value "ASSET_DOMAIN" %}/_css/main.compiled.css">
     <link rel="stylesheet" href="//code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Nunito+Sans">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Arvo">
-    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="https://network.mofoprod.net/_images/favicons/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="196x196" href="https://network.mofoprod.net/_images/favicons/favicon-196x196.png">
-    <link rel="shortcut icon" href="https://network.mofoprod.net/_images/favicons/favicon.ico">
+    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="https://{% settings_value "ASSET_DOMAIN" %}/_images/favicons/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="196x196" href="https://{% settings_value "ASSET_DOMAIN" %}/_images/favicons/favicon-196x196.png">
+    <link rel="shortcut icon" href="https://{% settings_value "ASSET_DOMAIN" %}/_images/favicons/favicon.ico">
     <title>Mozilla Network</title>
   </head>
   <body id="view-opportunity">
@@ -39,7 +40,7 @@
                   </div>
                   <div class="center-nav-title hidden-xs-down">
                     <p>{{ page.meta_title }}</p>
-                  </div><a class="btn btn-normal" href="/join">Join Us</a>
+                  </div><a class="btn btn-normal" href="/sign-up">Sign Up</a>
                 </div>
               </div>
             </div>
@@ -87,7 +88,7 @@
     </div>
   </body>
 </html>
-<script src="https://network.mofoprod.net/_js/main.compiled.js"></script>
+<script src="https://{% settings_value "ASSET_DOMAIN" %}/_js/main.compiled.js"></script>
 <script src="https://cdn.optimizely.com/js/206878104.js"></script>
 <script>
   (function () {

--- a/app/networkapi/utility/templatetags/settings_value.py
+++ b/app/networkapi/utility/templatetags/settings_value.py
@@ -1,0 +1,10 @@
+from django import template
+from mezzanine.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag(name='settings_value')
+def settings_value(key):
+    print(key)
+    return settings.__getattr__(str(key))

--- a/env.default
+++ b/env.default
@@ -10,3 +10,4 @@ SET_HSTS=False
 SSL_REDIRECT=False
 X_FRAME_OPTIONS=DENY
 ALLOWED_HOSTS=localhost
+ASSET_DOMAIN=network.mofoprod.net


### PR DESCRIPTION
This adds in a simple template tag for accessing django/mezzanine setting variables, and an `ASSET_DOMAIN` variable used in the langingpages template for "where to pull CSS etc from".

Also includes an updated landingpages template but that's essentially irrelevant given that the final template will come from the `network` repo.