### PR TITLE
Add branding to admin template

### DIFF
--- a/app/networkapi/templates/admin/includes_grappelli/header.html
+++ b/app/networkapi/templates/admin/includes_grappelli/header.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+
+<div id="header">
+    <div class="branding">&nbsp;</div>
+    <!-- Title -->
+    <div class="admin-title">Mozilla Network</div>
+    {% if user.is_authenticated and user.is_staff %}
+    <!-- Bookmarks (temporary) -->
+    <ul id="user-tools">
+        <!-- Username -->
+        <li><strong>{% firstof user.first_name user.username %}</strong></li>
+        <!-- Userlinks -->
+        {% block userlinks %}
+        <!-- Documentation -->
+        {% url "django-admindocs-docroot" as docsroot %}
+        {% if docsroot %}
+        <li><a href="{{ docsroot }}">{% trans 'Documentation' %}</a></li>
+        {% endif %}
+        <!-- Change Password -->
+        {% url "admin:password_change" as password_change_url %}
+        {% if password_change_url %}
+        <li><a href="{{ password_change_url }}">
+        {% else %}
+        <li><a href="{{ root_path }}password_change/">
+        {% endif %}
+        {% trans 'Change password' %}</a></li>
+        <!-- Logout -->
+        {% url "admin:logout" as logout_url %}
+        {% if logout_url %}
+        <li><a href="{{ logout_url }}">
+        {% else %}
+        <li><a href="{{ root_path }}logout/">
+        {% endif %}
+        {% trans 'Log out' %}</a></li>
+        {% endblock %}
+    </ul>
+    {% endif %}
+</div>


### PR DESCRIPTION
Closes #123 
(Used "Mozilla" instead of "moz://a" because it's getting automatically capitalized and we're not using the highlight. That is to say, it's text, not a logo.)