### PR TITLE
Make moz users staff by default

### DIFF
--- a/app/networkapi/settings.py
+++ b/app/networkapi/settings.py
@@ -139,6 +139,7 @@ if SOCIAL_SIGNIN:
         'social_core.pipeline.social_auth.social_user',
         'social_core.pipeline.user.get_username',
         'social_core.pipeline.user.create_user',
+        'networkapi.utility.userpermissions.set_user_permissions',
         'social_core.pipeline.social_auth.associate_user',
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',

--- a/app/networkapi/templates/admin/login.html
+++ b/app/networkapi/templates/admin/login.html
@@ -27,7 +27,7 @@
 
 
 <form action="{{ app_path }}" method="post" id="login-form">
-    {% if social %}
+    {% if backends %}
     <div class="social-login">
         <p>
         Log in <a href="{% url "social:begin" "google-oauth2" %}?next=/admin">with Google</a>.

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -23,11 +23,14 @@ def ismoz(email):
 def set_user_permissions(backend, user, response, *args, **kwargs):
     """
     This is a social-auth pipeline function for automatically
-    setting is_staff permissions when a user logs in from a
+    setting is_superuser permissions when a user logs in from a
     known-to-be mozilla account.
     """
 
+    attrs = vars(user)
+    print(', '.join("%s: %s" % item for item in attrs.items()))
+
     if user.email and ismoz(user.email):
-        if user.is_staff is False:
-            user.is_staff = True
+        if user.is_superuser is False:
+            user.is_superuser = True
             user.save()

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -1,33 +1,33 @@
 def ismoz(email):
-	"""
-	This function determines whether a particular email address is a
-	mozilla address or not. We strictly control mozilla.com and
-	mozillafoundation.org addresses, and so filtering on the email
-	domain section using exact string matching is acceptable.
-	"""
-	if email is None:
-		return False
+    """
+    This function determines whether a particular email address is a
+    mozilla address or not. We strictly control mozilla.com and
+    mozillafoundation.org addresses, and so filtering on the email
+    domain section using exact string matching is acceptable.
+    """
+    if email is None:
+        return False
 
-	parts = email.split('@')
-	domain = parts[1]
+    parts = email.split('@')
+    domain = parts[1]
 
-	if domain == 'mozilla.com':
-		return True
+    if domain == 'mozilla.com':
+        return True
 
-	if domain == 'mozillafoundation.org':
-		return True
+    if domain == 'mozillafoundation.org':
+        return True
 
-	return False
+    return False
 
 
 def set_user_permissions(backend, user, response, *args, **kwargs):
-	"""
-	This is a social-auth pipeline function for automatically
-	setting is_staff permissions when a user logs in from a 
-	known-to-be mozilla account.
-	"""
+    """
+    This is a social-auth pipeline function for automatically
+    setting is_staff permissions when a user logs in from a 
+    known-to-be mozilla account.
+    """
 
-	if user.email and ismoz(user.email):
-		if user.is_staff == False:
-			user.is_staff = True
-			user.save()
+    if user.email and ismoz(user.email):
+        if user.is_staff == False:
+            user.is_staff = True
+            user.save()

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -1,0 +1,33 @@
+def ismoz(email):
+	"""
+	This function determines whether a particular email address is a
+	mozilla address or not. We strictly control mozilla.com and
+	mozillafoundation.org addresses, and so filtering on the email
+	domain section using exact string matching is acceptable.
+	"""
+	if email is None:
+		return False
+
+	parts = email.split('@')
+	domain = parts[1]
+
+	if domain == 'mozilla.com':
+		return True
+
+	if domain == 'mozillafoundation.org':
+		return True
+
+	return False
+
+
+def set_user_permissions(backend, user, response, *args, **kwargs):
+	"""
+	This is a social-auth pipeline function for automatically
+	setting is_staff permissions when a user logs in from a 
+	known-to-be mozilla account.
+	"""
+
+	if user.email and ismoz(user.email):
+		if user.is_staff == False:
+			user.is_staff = True
+			user.save()

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -1,7 +1,6 @@
 from django.contrib.sites.models import Site
 from mezzanine.core.models import SitePermission
 
-DEBUG = False
 
 def ismoz(email):
     """
@@ -51,7 +50,7 @@ def set_user_permissions(backend, user, response, *args, **kwargs):
     known-to-be mozilla account.
     """
 
-    if user.email and ismoz(user.email) and user.is_staff == False:
+    if user.email and ismoz(user.email) and user.is_staff is False:
         user.is_staff = True
         user.save()
         add_user_to_main_site(user)

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -23,11 +23,11 @@ def ismoz(email):
 def set_user_permissions(backend, user, response, *args, **kwargs):
     """
     This is a social-auth pipeline function for automatically
-    setting is_staff permissions when a user logs in from a 
+    setting is_staff permissions when a user logs in from a
     known-to-be mozilla account.
     """
 
     if user.email and ismoz(user.email):
-        if user.is_staff == False:
+        if user.is_staff is False:
             user.is_staff = True
             user.save()

--- a/app/networkapi/utility/userpermissions.py
+++ b/app/networkapi/utility/userpermissions.py
@@ -31,6 +31,11 @@ def set_user_permissions(backend, user, response, *args, **kwargs):
     print(', '.join("%s: %s" % item for item in attrs.items()))
 
     if user.email and ismoz(user.email):
-        if user.is_superuser is False:
-            user.is_superuser = True
-            user.save()
+        user.is_staff = True
+
+        # For some reason just is_staff is not enough to get
+        # access to the admin view right now, and the 
+        # is_superuser flag needs to also be set to True...
+        user.is_superuser = True
+
+        user.save()


### PR DESCRIPTION
fixes https://github.com/mozilla/network-api/issues/170

This updates the social auth login such that any login from a mozilla account marks a user as staff (although not super admin)