### PR TITLE
give the network-pulse-api its own endpoint "namespace"

### DIFF
--- a/app/networkapi/urls.py
+++ b/app/networkapi/urls.py
@@ -26,13 +26,12 @@ urlpatterns = list(filter(None, [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^soc/', include('social_django.urls', namespace='social'))
     if settings.SOCIAL_SIGNIN else '',
-    # pulse api routing under the 'api' namespace for future use:
-    url(r'^api/', include('pulseapi.urls')),
+    # network-api routes:
     url(r'^api/people/', include('networkapi.people.urls')),
     url(r'^api/news/', include('networkapi.news.urls')),
+    # network-pulse-api routes (on their own namespace)
+    url(r'^api/pulse', include('pulseapi.urls')),
     url(r'^$', mezzanine.pages.views.page, {'slug': '/'}, name='home'),
-    # pulse api routing on the root to allow transitioning:
-    url(r'^', include('pulseapi.urls')),
     url(r'^', include('mezzanine.urls')),
 ]))
 


### PR DESCRIPTION
This sets the network-pulse-api routes to `.../api/pulse/...` so that there can
be no interference with routes defined by other apps running in parallel.