### PR TITLE
Views: Convert `queryset` attribute to `get_queryset()` function

### DIFF
--- a/app/networkapi/highlights/views.py
+++ b/app/networkapi/highlights/views.py
@@ -9,7 +9,9 @@ class HighlightListView(ListAPIView):
     A view that permits a GET to allow listing of Highlight
     in the database
     """
-    queryset = Highlight.objects.published()
+    def get_queryset(self):
+        return Highlight.objects.published()
+
     serializer_class = HighlightSerializer
 
 
@@ -17,5 +19,7 @@ class HighlightView(RetrieveAPIView):
     """
     A view that permits a GET request for an Highlight in the database
     """
-    queryset = Highlight.objects.published()
+    def get_queryset(self):
+        return Highlight.objects.published()
+
     serializer_class = HighlightSerializer

--- a/app/networkapi/news/views.py
+++ b/app/networkapi/news/views.py
@@ -9,7 +9,9 @@ class NewsListView(ListAPIView):
     A view that permits a GET to allow listing of News articles
     in the database
     """
-    queryset = News.objects.published()
+    def get_queryset(self):
+        return News.objects.published()
+
     serializer_class = NewsSerializer
     pagination_class = None
 
@@ -18,5 +20,7 @@ class NewsView(RetrieveAPIView):
     """
     A view that permits a GET request for a News article in the database
     """
-    queryset = News.objects.published()
+    def get_queryset(self):
+        return News.objects.published()
+
     serializer_class = NewsSerializer


### PR DESCRIPTION
Fixes https://github.com/mozilla/network-api/issues/232