### PR TITLE
Redirect 404s to `/errors/404`

### DIFF
--- a/app/networkapi/urls.py
+++ b/app/networkapi/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.contrib import admin
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 
 import mezzanine
 from mezzanine.conf import settings
@@ -35,7 +36,7 @@ urlpatterns = list(filter(None, [
 ]))
 
 
-handler404 = 'mezzanine.core.views.page_not_found'
+handler404 = RedirectView.as_view(url='/errors/404')
 handler500 = 'mezzanine.core.views.server_error'
 
 if settings.USE_S3 is not True:


### PR DESCRIPTION
Closes https://github.com/mozilla/network-api/issues/214