### PR TITLE
no leading slash in the static location for the admin login js file

### DIFF
--- a/app/networkapi/templates/admin/login.html
+++ b/app/networkapi/templates/admin/login.html
@@ -87,7 +87,7 @@
         </div>
     </div>
 
-    <script src="{% static "/js/admin/login-show-hide.js" %}"></script>
+    <script src="{% static "js/admin/login-show-hide.js" %}"></script>
 
 </form>
 {% endblock %}


### PR DESCRIPTION
This partially fixes deployment when `DEBUG=False`... and I don't know why. If this was truly "bad syntax for a static asset" then this should have failed irrespective of `DEBUG` setting, but instead it only fails when `DEBUG=False` and static assets are resolved by the Mezzanine asset server, rather than Django's built in static server....

Currently deployed on https://network-api-prod-test.herokuapp.com/admin/login/?next=/admin/ and as you can see, that no longer shows `400 bad request`

Still left:
- [ ] navigating to `pages` from the admin view should not break. Instead, it breaks right now (with `DEBUG=False`)