### PR TITLE
no leading slash in the static location for the pages override template

### DIFF
--- a/app/networkapi/templates/admin/pages/page/change_list.html
+++ b/app/networkapi/templates/admin/pages/page/change_list.html
@@ -16,7 +16,7 @@
 <script src="{% static "mezzanine/js/admin/jquery.mjs.nestedSortable.js" %}"></script>
 
 {# NOTE: THIS IS AN OVERRIDE ON MEZZANINE/JS/ADMIN/PAGE_TREE.JS #}
-<script src="{% static "/js/admin/page_tree.js" %}"></script>
+<script src="{% static "js/admin/page_tree.js" %}"></script>
 
 {% endblock %}
 


### PR DESCRIPTION
Similar to #237, this removes the leading slash in the path to the custom js in `app/networkapi/templates/admin/pages/page/change_list.html` 

@Pomax feel free to review this on Thrusday, I'm just putting it out there now.