### PR TITLE
removed remaining leading slash after static tag

### DIFF
--- a/app/networkapi/templates/admin/pages/page/change_list.html
+++ b/app/networkapi/templates/admin/pages/page/change_list.html
@@ -16,7 +16,7 @@
 <script src="{% static "mezzanine/js/admin/jquery.mjs.nestedSortable.js" %}"></script>
 
 {# NOTE: THIS IS AN OVERRIDE ON MEZZANINE/JS/ADMIN/PAGE_TREE.JS #}
-<script src="{% static "/js/admin/page_tree.js" %}"></script>
+<script src="{% static "js/admin/page_tree.js" %}"></script>
 
 {% endblock %}
 

--- a/app/networkapi/templates/pages/menus/admin.html
+++ b/app/networkapi/templates/pages/menus/admin.html
@@ -1,6 +1,6 @@
 {% load pages_tags i18n staticfiles %}
 
-<link rel="stylesheet" href="{% static "/css/content_typed_change_list.css" %}">
+<link rel="stylesheet" href="{% static "css/content_typed_change_list.css" %}">
 
 <ol>
     {% for page in page_branch %}
@@ -9,7 +9,7 @@
         <div class="{% cycle 'row1' 'row2' %}">
 
             {% set_page_permissions page %}
-            
+
             {% if page.perms.change %}
 
                 {% if page.is_primary %}


### PR DESCRIPTION
supercedes https://github.com/mozilla/network-api/pull/239, fixes the leading slash fixed in that PR as well as one more that was hiding out in the code.